### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-all</artifactId>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-annotations</artifactId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,7 +28,7 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
     </dependencies>
@@ -58,12 +58,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/annotations/**</include>
                             </includes>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-base</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,11 +28,11 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
     </dependencies>
@@ -62,12 +62,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/base/**</include>
                                 <include>org/forgerock/guava/common/base/internal/**</include>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,27 +28,27 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-concurrent</artifactId>
         </dependency>
     </dependencies>
@@ -78,12 +78,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/cache/**</include>
                             </includes>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-cache</artifactId>

--- a/collect/pom.xml
+++ b/collect/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,23 +28,23 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-math</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -74,12 +74,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/collect/**</include>
                             </includes>

--- a/collect/pom.xml
+++ b/collect/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-collect</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-concurrent</artifactId>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,27 +28,27 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-math</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -78,12 +78,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/util/concurrent/**</include>
                             </includes>

--- a/escape/pom.xml
+++ b/escape/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-escape</artifactId>

--- a/escape/pom.xml
+++ b/escape/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,15 +28,15 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
     </dependencies>
@@ -66,12 +66,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/escape/**</include>
                             </includes>

--- a/eventbus/pom.xml
+++ b/eventbus/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-eventbus</artifactId>

--- a/eventbus/pom.xml
+++ b/eventbus/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,31 +28,31 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-cache</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-reflect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-concurrent</artifactId>
         </dependency>
     </dependencies>
@@ -82,12 +82,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/eventbus/**</include>
                             </includes>

--- a/hash/pom.xml
+++ b/hash/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,23 +28,23 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-math</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -74,12 +74,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/hash/**</include>
                             </includes>

--- a/hash/pom.xml
+++ b/hash/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-hash</artifactId>

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-html</artifactId>

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,15 +28,15 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-escape</artifactId>
         </dependency>
     </dependencies>
@@ -66,12 +66,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/html/**</include>
                             </includes>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-io</artifactId>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,27 +28,27 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-hash</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -78,12 +78,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/io/**</include>
                             </includes>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -27,15 +27,15 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -65,12 +65,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/math/**</include>
                             </includes>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-math</artifactId>

--- a/net/pom.xml
+++ b/net/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-net</artifactId>

--- a/net/pom.xml
+++ b/net/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,35 +28,35 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-escape</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-hash</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -86,12 +86,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/net/**</include>
                                 <include>org/forgerock/guava/thirdparty/publicsuffix/**</include>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>jp.openam.commons.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,22 +183,9 @@
             </plugins>
         </pluginManagement>
     </build>
-    <!-- Maven Repositories -->
-    <repositories>
-        <!-- ForgeRock Common Internal Project Repositories -->
-        <repository>
-            <id>forgerock-staging-repo</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guava.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guava.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-guava/browse</url>
-      <tag>18.0.4</tag>
-  </scm>
- </project>
+        <connection>scm:git:https://github.com/openam-jp/forgerock-guava.git</connection>
+        <developerConnection>scm:git:git@github.com:openam-jp/forgerock-guava.git</developerConnection>
+        <url>https://github.com/openam-jp/forgerock-guava</url>
+    </scm>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock</groupId>
+        <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.4</version>
     </parent>
     <packaging>pom</packaging>
-    <groupId>org.forgerock.commons.guava</groupId>
+    <groupId>jp.openam.commons.guava</groupId>
     <artifactId>forgerock-guava</artifactId>
     <version>18.0.5-SNAPSHOT</version>
     <name>ForgeRock Guava</name>
@@ -62,77 +62,77 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-all</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-annotations</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-base</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-collect</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-concurrent</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-escape</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-eventbus</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-hash</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-io</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-math</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-net</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-primitives</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-reflect</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons.guava</groupId>
+                <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-xml</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
  
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,7 +25,7 @@
     <packaging>pom</packaging>
     <groupId>org.forgerock.commons.guava</groupId>
     <artifactId>forgerock-guava</artifactId>
-    <version>18.0.4</version>
+    <version>18.0.5-SNAPSHOT</version>
     <name>ForgeRock Guava</name>
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <modules>

--- a/primitives/pom.xml
+++ b/primitives/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,15 +28,15 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
     </dependencies>
@@ -66,12 +66,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/primitives/**</include>
                             </includes>

--- a/primitives/pom.xml
+++ b/primitives/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-primitives</artifactId>

--- a/reflect/pom.xml
+++ b/reflect/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-reflect</artifactId>

--- a/reflect/pom.xml
+++ b/reflect/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,23 +28,23 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-primitives</artifactId>
         </dependency>
     </dependencies>
@@ -74,12 +74,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/reflect/**</include>
                             </includes>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -13,13 +13,14 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014-2015 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.forgerock.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
-        <version>18.0.4</version>
+        <version>18.0.5-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>forgerock-guava-xml</artifactId>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock.commons.guava</groupId>
+        <groupId>jp.openam.commons.guava</groupId>
         <artifactId>forgerock-guava</artifactId>
         <version>18.0.5-SNAPSHOT</version>
     </parent>
@@ -28,15 +28,15 @@
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-escape</artifactId>
         </dependency>
     </dependencies>
@@ -66,12 +66,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.forgerock.commons.guava:forgerock-guava-all</include>
+                            <include>jp.openam.commons.guava:forgerock-guava-all</include>
                         </includes>
                     </artifactSet>
                     <filters>
                         <filter>
-                            <artifact>org.forgerock.commons.guava:forgerock-guava-all</artifact>
+                            <artifact>jp.openam.commons.guava:forgerock-guava-all</artifact>
                             <includes>
                                 <include>org/forgerock/guava/common/xml/**</include>
                             </includes>


### PR DESCRIPTION
## Analysis
This project is utilities for ForgeRock projects (Repackaged Google Guava).

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-guava
```

## Regression testing
N/A