### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -14,6 +14,7 @@
 
   Copyright 2014-2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -26,11 +27,21 @@
     <artifactId>forgerock-guava-all</artifactId>
     <name>Google Guava</name>
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>jp.openam.commons</groupId>
+          <artifactId>forgerock-bom</artifactId>
+          <version>4.1.2-SNAPSHOT</version>
+          <scope>import</scope>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -27,17 +27,6 @@
     <artifactId>forgerock-guava-all</artifactId>
     <name>Google Guava</name>
     <description>Repackaged version of Guava to avoid dependency collisions.</description>
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>jp.openam.commons</groupId>
-          <artifactId>forgerock-bom</artifactId>
-          <version>4.1.2-SNAPSHOT</version>
-          <scope>import</scope>
-          <type>pom</type>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
  
   Copyright 2014-2015 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,6 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>1.3.9</version>
             <optional>true</optional>
             <scope>provided</scope>
             <!--  needed only for annotations  -->
@@ -61,6 +61,13 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>jp.openam.commons</groupId>
+                <artifactId>forgerock-bom</artifactId>
+                <version>4.1.2-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>jp.openam.commons.guava</groupId>
                 <artifactId>forgerock-guava-all</artifactId>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
